### PR TITLE
Make _publishCursor return a handle with a stop method

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -24,5 +24,9 @@ Counter.prototype._publishCursor = function(sub) {
   sub.onStop(function() {
     Meteor.clearTimeout(handler);
   });
+
+  return {
+    stop: sub.onStop.bind(sub)
+  }
 };
 


### PR DESCRIPTION
This ensures that packages that rely on the handle following the API can use publications created with this counter (example johanbrook/meteor-publication-collector)